### PR TITLE
Avoid delete trash icons to overlap

### DIFF
--- a/src/less/styles.less
+++ b/src/less/styles.less
@@ -121,7 +121,7 @@ a {
 
 #github-link {
   .linkBox();
-
+  z-index: 100;
 }
 
 #feedback-link {


### PR DESCRIPTION
The trash icon was on top of the github link :smile: 